### PR TITLE
Add CommonJS support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ export default = fooController;
 will compile to `/assets/controllers/fooController.js`
 
 ```js
-define("controllers/fooController", 
+define("controllers/fooController",
   ["exports"],
   function(__exports__) {
     "use strict";
@@ -47,10 +47,12 @@ define("controllers/fooController",
 
 ### Compiling ###
 
-By default your module will compile to an AMD. If you wish to compile it as a global just make the following switch:
+By default your module will compile to an AMD. You can also compile it to globals or CommonJS by making the following switch:
 
 ```ruby
-ES6ModuleTranspiler.compile_to = :global
+ES6ModuleTranspiler.compile_to = :globals
+# or
+ES6ModuleTranspiler.compile_to = :cjs
 ```
 
 ## Authors ##

--- a/lib/es6_module_transpiler/tilt/es6_module_transpiler_template.rb
+++ b/lib/es6_module_transpiler/tilt/es6_module_transpiler_template.rb
@@ -13,7 +13,7 @@ module Tilt
 
     def prepare
       # intentionally left empty
-      # ExecJS requires this method to be defined
+      # Tilt requires this method to be defined
     end
 
     def evaluate(scope, locals, &block)

--- a/lib/es6_module_transpiler/tilt/es6_module_transpiler_template.rb
+++ b/lib/es6_module_transpiler/tilt/es6_module_transpiler_template.rb
@@ -31,8 +31,18 @@ module Tilt
         var Compiler, compiler, output;
         Compiler = require("#{transpiler_path}").Compiler;
         compiler = new Compiler(#{::JSON.generate(data, quirks_mode: true)}, '#{scope.logical_path}');
-        return output = compiler.#{ES6ModuleTranspiler.compile_to.to_sym == :global ? 'toGlobals' : 'toAMD'}();
+        return output = compiler.#{compiler_method}();
       SOURCE
+    end
+
+    def compiler_method
+      type = {
+        amd: 'AMD',
+        cjs: 'CJS',
+        globals: 'Globals'
+      }[ES6ModuleTranspiler.compile_to.to_sym]
+
+      "to#{type}"
     end
   end
 end

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -40,8 +40,8 @@ JS
     template.render(@scope).must_equal expected
   end
 
-  it 'transpiles es6 into global when set' do
-    ES6ModuleTranspiler.compile_to = :global
+  it 'transpiles es6 into globals when set' do
+    ES6ModuleTranspiler.compile_to = :globals
 
     expected = <<-JS
 (function(__exports__) {
@@ -52,6 +52,23 @@ JS
 
   __exports__.foo = foo;
 })(window);
+JS
+    expected.rstrip!
+
+    template = Tilt::ES6ModuleTranspilerTemplate.new { @source }
+    template.render(@scope).must_equal expected
+  end
+
+  it 'transpiles es6 into CommonJS when set' do
+    ES6ModuleTranspiler.compile_to = :cjs
+
+    expected = <<-JS
+"use strict";
+var foo = function() {
+  console.log('bar');
+};
+
+exports["default"] = foo;
 JS
     expected.rstrip!
 


### PR DESCRIPTION
This PR adds the option to compile to CommonJS modules and switches the `:global` option to `:globals` to match the options of es6-module-transpiler's compile-modules executable.
