### PR TITLE
Refactor `prefix_pattern` API.

### DIFF
--- a/lib/es6_module_transpiler/rails.rb
+++ b/lib/es6_module_transpiler/rails.rb
@@ -11,11 +11,25 @@ module ES6ModuleTranspiler
     @compile_to = target
   end
 
-  def self.prefix_pattern
-    @prefix_pattern || []
+  def self.prefix_patterns
+    @prefix_patterns ||= []
+  end
+
+  def self.prefix_patterns=(patterns)
+    @prefix_patterns = patterns
   end
 
   def self.prefix_pattern=(pattern)
-    @prefix_pattern = pattern
+    self.prefix_patterns = [pattern]
+  end
+
+  def self.add_prefix_pattern(pattern, prefix)
+    prefix_patterns << [pattern, prefix]
+  end
+
+  def self.lookup_prefix(path)
+    _, prefix = prefix_patterns.detect {|pattern, prefix| pattern =~ path }
+
+    prefix
   end
 end

--- a/lib/es6_module_transpiler/tilt/es6_module_transpiler_template.rb
+++ b/lib/es6_module_transpiler/tilt/es6_module_transpiler_template.rb
@@ -36,8 +36,8 @@ module Tilt
     end
 
     def module_name(path)
-      if ES6ModuleTranspiler.prefix_pattern[0] === path
-        path = "#{ES6ModuleTranspiler.prefix_pattern[1]}/#{path}"
+      if prefix = ES6ModuleTranspiler.lookup_prefix(path)
+        path = "#{prefix}/#{path}"
       end
 
       path


### PR DESCRIPTION
Add ability to match multiple patterns. This also allows easy customization without have to maintain a single regex pattern.

Using the following initial prefix (using the current API):

``` ruby
  ES6ModuleTranspiler.prefix_pattern = [/^(controllers|models|views|helpers|routes|router|adapter)/, 'appkit']
```

Adding a new pattern to be matched (and using multiple prefixes):

``` ruby
  ES6ModuleTranspiler.prefix_pattern = [/^(controllers|models|views|helpers|routes|router|adapter)/, 'appkit']

  ES6ModuleTranspiler.add_prefix_pattern /^components/, 'appkit'
  ES6ModuleTranspiler.add_prefix_pattern /^gui-helpers/, 'gui'
```

This  makes it much easier to slightly tweak the pattern (to add an extra folder or prefix for example).

The previous API (using `ES6ModuleTranspiler.prefix_pattern=`) is still fully functional, and a test has been added to ensure it works properly.
