### PR TITLE
Bump transpiler version

### DIFF
--- a/lib/es6_module_transpiler/support/es6-module-transpiler.js
+++ b/lib/es6_module_transpiler/support/es6-module-transpiler.js
@@ -6433,7 +6433,7 @@ var CJSCompiler = function($__super) {
     },
     doModuleImport: function(name, dependencyName, idx) {
       this.ensureHasModuleObjectBuilder();
-      return ("var " + name + " = " + MODULE_OBJECT_BUILDER_NAME + "(\"" + name + "\", require(\"" + name + "\"));\n");
+      return ("var " + name + " = " + MODULE_OBJECT_BUILDER_NAME + "(\"" + name + "\", require(\"" + dependencyName + "\"));\n");
     },
     ensureHasModuleObjectBuilder: function() {
       this.ensureHasSafeWarn();


### PR DESCRIPTION
The version of the transpiler currently being used is slightly outdated (not by much)
This includes the latest version.

`rake test` still passes all tests 
