### PR TITLE
Expose the ES6 module transpiler compiler options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+* Added `ES6ModuleTranspiler.compiler_options` for passing options to the
+  module compiler.
+
 ## 0.3.0
 
 * Added ES6ModuleTranspiler.transform for custom transforming of the

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ ES6ModuleTranspiler.compile_to = :globals
 ES6ModuleTranspiler.compile_to = :cjs
 ```
 
+You may modify the `options` that are passed to the module compiler (i.e.
+[compatFix](https://github.com/square/es6-module-transpiler/blob/3e708b70dffeaf753307f9d5ecdf780fd6c7b74e/lib/amd_compiler.js#L68)) by 
+modifying the `compiler_options` hash:
+
+```ruby
+ES6ModuleTranspiler.compiler_options[:compatFix] = true;
+```
+
+The `compiler_options` hash is empty by default.
+
 ### Custom Module Prefix ###
 
 You can match module names based upon a pattern to apply a prefix to the

--- a/lib/es6_module_transpiler/rails.rb
+++ b/lib/es6_module_transpiler/rails.rb
@@ -32,4 +32,8 @@ module ES6ModuleTranspiler
   def self.transform
     @transform
   end
+
+  def self.compiler_options
+    @compiler_options ||= {}
+  end
 end

--- a/lib/es6_module_transpiler/tilt/es6_module_transpiler_template.rb
+++ b/lib/es6_module_transpiler/tilt/es6_module_transpiler_template.rb
@@ -27,10 +27,10 @@ module Tilt
     end
 
     def generate_source(scope)
-      source = <<-SOURCE
+      <<-SOURCE
         var Compiler, compiler, output;
         Compiler = require("#{transpiler_path}").Compiler;
-        compiler = new Compiler(#{::JSON.generate(data, quirks_mode: true)}, '#{module_name(scope.root_path, scope.logical_path)}');
+        compiler = new Compiler(#{::JSON.generate(data, quirks_mode: true)}, '#{module_name(scope.root_path, scope.logical_path)}', #{compiler_options});
         return output = compiler.#{compiler_method}();
       SOURCE
     end
@@ -58,6 +58,10 @@ module Tilt
       }[ES6ModuleTranspiler.compile_to.to_sym]
 
       "to#{type}"
+    end
+
+    def compiler_options
+      ::JSON.generate(ES6ModuleTranspiler.compiler_options, quirks_mode: true)
     end
   end
 end


### PR DESCRIPTION
This allows users to take advantage of current and future options in the
Compiler constructor. The one I was most interested in (and led me to write this
commit) is `compatFix` which allows transpiled files to work seemlessly with
non-transpiled. For example:

``` rb
ES6ModuleTranspiler.compiler_options[:compatFix] = true
```

I also improved the tests by adding the `import` directive to ensure it gets transpiled correctly in addition to `export`.
