### PR TITLE
Add minitest as development dependency for Ruby 2.2

### DIFF
--- a/es6_module_transpiler-rails.gemspec
+++ b/es6_module_transpiler-rails.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'tilt'
   spec.add_development_dependency 'sprockets', '> 2.0.0'
+  spec.add_development_dependency 'minitest'
 end


### PR DESCRIPTION
minitest is not bundled stdlib in Ruby 2.2.
see: https://bugs.ruby-lang.org/issues/9711
